### PR TITLE
Switch UI to light theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -12,13 +12,6 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
   background: var(--background);
   color: var(--foreground);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -110,11 +110,11 @@ export default function HomePage() {
   
 
   return (
-    <main className="flex min-h-screen flex-col items-center p-4 md:p-8 lg:p-12 bg-gray-900 text-white">
+    <main className="flex min-h-screen flex-col items-center p-4 md:p-8 lg:p-12 bg-white text-gray-900">
       <div className="w-full max-w-5xl font-sans">
 
         {/* --- INTERACTION HEADER --- */}
-        <div className="p-4 mb-8 bg-gray-800 rounded-lg shadow-lg">
+        <div className="p-4 mb-8 bg-gray-100 rounded-lg shadow-lg">
           <h1 className="text-2xl font-bold text-center text-cyan-400 mb-4">Analyze a News Topic</h1>
           <div className="flex flex-col sm:flex-row gap-2">
             <input
@@ -123,22 +123,22 @@ export default function HomePage() {
               onChange={(e) => setTopicInput(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder="Enter a topic (e.g., 'Global supply chain')"
-              className="flex-grow p-2 rounded bg-gray-700 text-white border border-gray-600 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+              className="flex-grow p-2 rounded bg-gray-200 text-gray-900 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-cyan-500"
             />
-            <button onClick={handleAnalyzeClick} disabled={isLoading} className="px-4 py-2 bg-cyan-600 rounded hover:bg-cyan-700 disabled:bg-gray-500 transition-colors">
+            <button onClick={handleAnalyzeClick} disabled={isLoading} className="px-4 py-2 bg-cyan-600 rounded hover:bg-cyan-700 disabled:bg-gray-300 transition-colors">
               {isLoading ? 'Analyzing...' : 'Analyze'}
             </button>
             <button
               onClick={handleClearClick}
               disabled={!topicInput}
-              className="px-4 py-2 bg-gray-600 rounded hover:bg-gray-700 disabled:bg-gray-500 transition-colors"
+              className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300 disabled:bg-gray-100 transition-colors"
             >
               Clear
             </button>
           </div>
 
-          <div className="mt-4 pt-4 border-t border-gray-700">
-            <p className="text-center text-sm text-gray-400 mb-3">Or select a trending topic:</p>
+          <div className="mt-4 pt-4 border-t border-gray-300">
+            <p className="text-center text-sm text-gray-600 mb-3">Or select a trending topic:</p>
             <div className="flex flex-wrap justify-center items-center gap-2">
               {suggestedTopics.length > 0 ? (
                 (showAllTopics ? suggestedTopics : suggestedTopics.slice(0, 4)).map(topic => (
@@ -146,7 +146,7 @@ export default function HomePage() {
                     key={topic}
                     onClick={() => { setTopicInput(topic); fetchAnalysis(topic); }}
                     disabled={isLoading}
-                    className="px-3 py-1 bg-gray-700 text-sm rounded-full hover:bg-cyan-700 disabled:bg-gray-600 transition-colors"
+                    className="px-3 py-1 bg-gray-200 text-sm rounded-full hover:bg-cyan-100 disabled:bg-gray-100 transition-colors"
                   >
                     {topic}
                   </button>
@@ -169,7 +169,7 @@ export default function HomePage() {
           </div>
 
           <div className="text-center mt-4">
-            <button onClick={handleRandomClick} disabled={isLoading || suggestedTopics.length === 0} className="text-sm text-gray-400 hover:text-cyan-400 disabled:text-gray-600 transition-colors">
+            <button onClick={handleRandomClick} disabled={isLoading || suggestedTopics.length === 0} className="text-sm text-gray-600 hover:text-cyan-600 disabled:text-gray-400 transition-colors">
               or analyze a random topic
             </button>
           </div>
@@ -181,43 +181,43 @@ export default function HomePage() {
           {error && <ErrorMessage message={error} />}
           {analysis && (
             <div className="animate-fade-in">
-              <header className="mb-12 border-b border-gray-700 pb-4 text-center">
+              <header className="mb-12 border-b border-gray-300 pb-4 text-center">
                 <h2 className="text-4xl font-bold text-cyan-400">{analysis.topic}</h2>
-                <p className="mt-3 text-lg text-gray-300 max-w-3xl mx-auto">{analysis.summary}</p>
+                <p className="mt-3 text-lg text-gray-700 max-w-3xl mx-auto">{analysis.summary}</p>
               </header>
 
               <AnimatedSection>
-                <div className="p-6 bg-gray-800 rounded-lg shadow-lg">
-                  <h2 className="text-2xl font-semibold text-gray-200 mb-3">The Aggregated Problem</h2>
-                  <p className="text-lg text-gray-300 leading-relaxed">{analysis.aggregatedProblem}</p>
+                <div className="p-6 bg-gray-100 rounded-lg shadow-lg">
+                  <h2 className="text-2xl font-semibold text-gray-900 mb-3">The Aggregated Problem</h2>
+                  <p className="text-lg text-gray-700 leading-relaxed">{analysis.aggregatedProblem}</p>
                 </div>
               </AnimatedSection>
 
               <AnimatedSection>
-                <h2 className="text-2xl font-semibold text-gray-200 mb-3 text-center">Proposed Solution</h2>
-                <p className="text-lg text-center text-cyan-300 leading-relaxed max-w-3xl mx-auto">{analysis.solutionProposal}</p>
+                <h2 className="text-2xl font-semibold text-gray-900 mb-3 text-center">Proposed Solution</h2>
+                <p className="text-lg text-center text-cyan-700 leading-relaxed max-w-3xl mx-auto">{analysis.solutionProposal}</p>
               </AnimatedSection>
 
               <AnimatedSection>
                 <div className="grid md:grid-cols-2 gap-8 text-sm">
-                  <section className="p-4 border border-gray-700 rounded-lg">
-                    <h3 className="text-xl font-semibold text-gray-200 mb-3">Proposing Viewpoint</h3>
-                    <p className="text-gray-400 leading-relaxed">{analysis.proposingViewpoint}</p>
+                  <section className="p-4 bg-gray-100 border border-gray-300 rounded-lg">
+                    <h3 className="text-xl font-semibold text-gray-900 mb-3">Proposing Viewpoint</h3>
+                    <p className="text-gray-700 leading-relaxed">{analysis.proposingViewpoint}</p>
                   </section>
-                  <section className="p-4 border border-gray-700 rounded-lg">
-                    <h3 className="text-xl font-semibold text-gray-200 mb-3">Opposing Viewpoint</h3>
-                    <p className="text-gray-400 leading-relaxed">{analysis.opposingViewpoint}</p>
+                  <section className="p-4 bg-gray-100 border border-gray-300 rounded-lg">
+                    <h3 className="text-xl font-semibold text-gray-900 mb-3">Opposing Viewpoint</h3>
+                    <p className="text-gray-700 leading-relaxed">{analysis.opposingViewpoint}</p>
                   </section>
                 </div>
               </AnimatedSection>
 
               <AnimatedSection>
-                <h3 className="text-xl font-semibold text-gray-200 mb-3">Historical Perspective</h3>
-                <p className="text-gray-400 leading-relaxed">{analysis.historicalPerspective}</p>
+                <h3 className="text-xl font-semibold text-gray-900 mb-3">Historical Perspective</h3>
+                <p className="text-gray-700 leading-relaxed">{analysis.historicalPerspective}</p>
               </AnimatedSection>
 
-              <footer className="mt-12 pt-6 border-t border-gray-700 text-center">
-                <p className="text-md text-gray-500 italic">&quot;{analysis.motivationalProverb}&quot;</p>
+              <footer className="mt-12 pt-6 border-t border-gray-300 text-center">
+                <p className="text-md text-gray-600 italic">&quot;{analysis.motivationalProverb}&quot;</p>
               </footer>
             </div>
           )}
@@ -230,18 +230,18 @@ export default function HomePage() {
 const LoadingSkeleton = () => (
   <div className="w-full animate-pulse">
     {/* Simplified version of your previous loading skeleton */}
-    <div className="h-10 bg-gray-700 rounded-md w-3/4 mx-auto mb-4"></div>
-    <div className="mt-4 h-5 bg-gray-700 rounded-md w-full"></div>
-    <div className="mt-8 p-6 bg-gray-800 rounded-lg">
-      <div className="h-8 bg-gray-700 rounded-md w-1/3 mb-4"></div>
-      <div className="h-6 bg-gray-700 rounded-md w-full"></div>
+    <div className="h-10 bg-gray-200 rounded-md w-3/4 mx-auto mb-4"></div>
+    <div className="mt-4 h-5 bg-gray-200 rounded-md w-full"></div>
+    <div className="mt-8 p-6 bg-gray-100 rounded-lg">
+      <div className="h-8 bg-gray-200 rounded-md w-1/3 mb-4"></div>
+      <div className="h-6 bg-gray-200 rounded-md w-full"></div>
     </div>
   </div>
 );
 
 const ErrorMessage = ({ message }: { message: string }) => (
-  <div className="p-4 bg-red-900/50 border border-red-700 rounded-lg text-center">
-    <p className="font-bold text-red-400">Analysis Failed</p>
-    <p className="text-red-300">{message}</p>
+  <div className="p-4 bg-red-100 border border-red-300 rounded-lg text-center">
+    <p className="font-bold text-red-700">Analysis Failed</p>
+    <p className="text-red-600">{message}</p>
   </div>
 );


### PR DESCRIPTION
## Summary
- remove dark mode override and default to light colors
- use light palette across homepage sections, skeleton, and error message

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font file)*

------
https://chatgpt.com/codex/tasks/task_e_688dac1e8cb0832db68b443a6a685db6