### PR TITLE
Refactor home page into modular components

### DIFF
--- a/app/components/AnalysisResults.tsx
+++ b/app/components/AnalysisResults.tsx
@@ -1,0 +1,56 @@
+'use client';
+import { ProblemAnalysis } from '../types';
+import { AnimatedSection } from './AnimatedSection';
+
+interface AnalysisResultsProps {
+  analysis: ProblemAnalysis;
+}
+
+export const AnalysisResults = ({ analysis }: AnalysisResultsProps) => (
+  <div className="space-y-8">
+    <header className="text-center space-y-3">
+      <h2 className="text-3xl sm:text-4xl font-bold text-cyan-600">{analysis.topic}</h2>
+      <p className="text-base sm:text-lg text-gray-700 max-w-3xl mx-auto">{analysis.summary}</p>
+    </header>
+
+    <AnimatedSection>
+      <div className="bg-white rounded shadow p-6">
+        <h3 className="text-xl font-semibold mb-3">The Aggregated Problem</h3>
+        <p className="text-gray-700 leading-relaxed">{analysis.aggregatedProblem}</p>
+      </div>
+    </AnimatedSection>
+
+    <AnimatedSection>
+      <div className="bg-white rounded shadow p-6 text-center">
+        <h3 className="text-xl font-semibold mb-3">Proposed Solution</h3>
+        <p className="text-gray-700 leading-relaxed">{analysis.solutionProposal}</p>
+      </div>
+    </AnimatedSection>
+
+    <AnimatedSection>
+      <div className="grid sm:grid-cols-2 gap-6">
+        <div className="bg-white rounded shadow p-4">
+          <h4 className="text-lg font-semibold mb-2">Proposing Viewpoint</h4>
+          <p className="text-gray-700 leading-relaxed">{analysis.proposingViewpoint}</p>
+        </div>
+        <div className="bg-white rounded shadow p-4">
+          <h4 className="text-lg font-semibold mb-2">Opposing Viewpoint</h4>
+          <p className="text-gray-700 leading-relaxed">{analysis.opposingViewpoint}</p>
+        </div>
+      </div>
+    </AnimatedSection>
+
+    <AnimatedSection>
+      <div className="bg-white rounded shadow p-4">
+        <h4 className="text-lg font-semibold mb-2">Historical Perspective</h4>
+        <p className="text-gray-700 leading-relaxed">{analysis.historicalPerspective}</p>
+      </div>
+    </AnimatedSection>
+
+    <footer className="text-center pt-4">
+      <p className="text-gray-500 italic">&quot;{analysis.motivationalProverb}&quot;</p>
+    </footer>
+  </div>
+);
+
+export default AnalysisResults;

--- a/app/components/SearchBar.tsx
+++ b/app/components/SearchBar.tsx
@@ -1,0 +1,61 @@
+'use client';
+import React from 'react';
+
+interface SearchBarProps {
+  topic: string;
+  onTopicChange: (value: string) => void;
+  onAnalyze: () => void;
+  onClear: () => void;
+  onRandom: () => void;
+  isLoading: boolean;
+  onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+}
+
+export const SearchBar = ({
+  topic,
+  onTopicChange,
+  onAnalyze,
+  onClear,
+  onRandom,
+  isLoading,
+  onKeyDown,
+}: SearchBarProps) => (
+  <div className="p-4 bg-gray-800 rounded-lg shadow space-y-4">
+    <h1 className="text-2xl font-bold text-center text-cyan-400">Analyze a News Topic</h1>
+    <div className="flex flex-col sm:flex-row gap-2">
+      <input
+        type="text"
+        value={topic}
+        onChange={(e) => onTopicChange(e.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder="Enter a topic"
+        className="flex-1 px-4 py-2 rounded bg-gray-700 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+      />
+      <button
+        onClick={onAnalyze}
+        disabled={isLoading}
+        className="px-4 py-2 bg-cyan-600 text-white rounded hover:bg-cyan-700 disabled:bg-cyan-400 transition-colors"
+      >
+        {isLoading ? 'Analyzing...' : 'Analyze'}
+      </button>
+      <button
+        onClick={onClear}
+        disabled={!topic}
+        className="px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-700 disabled:bg-gray-500 transition-colors"
+      >
+        Clear
+      </button>
+    </div>
+    <div className="text-center">
+      <button
+        onClick={onRandom}
+        disabled={isLoading}
+        className="text-sm text-gray-400 hover:text-cyan-400 disabled:text-gray-600 transition-colors"
+      >
+        or analyze a random topic
+      </button>
+    </div>
+  </div>
+);
+
+export default SearchBar;

--- a/app/components/TopicSuggestions.tsx
+++ b/app/components/TopicSuggestions.tsx
@@ -1,0 +1,55 @@
+'use client';
+import { useState } from 'react';
+
+interface TopicSuggestionsProps {
+  topics: string[];
+  onSelect: (topic: string) => void;
+  isLoading: boolean;
+}
+
+export const TopicSuggestions = ({ topics, onSelect, isLoading }: TopicSuggestionsProps) => {
+  const [showAll, setShowAll] = useState(false);
+  const visibleTopics = showAll ? topics : topics.slice(0, 4);
+
+  return (
+    <div className="pt-4 border-t border-gray-700">
+      <p className="text-center text-sm text-gray-400 mb-3">Or select a trending topic:</p>
+      <div className="flex flex-wrap justify-center items-center gap-2">
+        {topics.length > 0 ? (
+          <>
+            {visibleTopics.map((topic) => (
+              <button
+                key={topic}
+                onClick={() => onSelect(topic)}
+                disabled={isLoading}
+                className="px-3 py-1 bg-gray-700 text-sm rounded-full hover:bg-cyan-700 disabled:bg-gray-600 transition-colors"
+              >
+                {topic}
+              </button>
+            ))}
+            {topics.length > 4 && !showAll && (
+              <button
+                onClick={() => setShowAll(true)}
+                className="px-3 py-1 text-sm text-cyan-400 hover:text-cyan-300"
+              >
+                Show More...
+              </button>
+            )}
+            {topics.length > 4 && showAll && (
+              <button
+                onClick={() => setShowAll(false)}
+                className="px-3 py-1 text-sm text-cyan-400 hover:text-cyan-300"
+              >
+                Show Less
+              </button>
+            )}
+          </>
+        ) : (
+          <p className="text-xs text-gray-500">Loading topics...</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TopicSuggestions;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,30 +1,20 @@
-'use client'; // This directive turns the page into a Client Component
+'use client';
 
-import { AnimatedSection } from './components/AnimatedSection';
 import { useState, useEffect } from 'react';
+import { SearchBar } from './components/SearchBar';
+import { TopicSuggestions } from './components/TopicSuggestions';
+import { AnalysisResults } from './components/AnalysisResults';
+import { ProblemAnalysis } from './types';
 
 // const API_BASE_URL = 'http://localhost:8080';
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
-
-// The ProblemAnalysis interface remains the same
-interface ProblemAnalysis {
-  topic: string;
-  summary: string;
-  aggregatedProblem: string;
-  solutionProposal: string;
-  proposingViewpoint: string;
-  opposingViewpoint: string;
-  historicalPerspective: string;
-  motivationalProverb: string;
-}
 
 export default function HomePage() {
   const [analysis, setAnalysis] = useState<ProblemAnalysis | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [topicInput, setTopicInput] = useState("");
+  const [topicInput, setTopicInput] = useState('');
   const [suggestedTopics, setSuggestedTopics] = useState<string[]>([]);
-  const [showAllTopics, setShowAllTopics] = useState(false);
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
@@ -41,7 +31,7 @@ export default function HomePage() {
         setSuggestedTopics(topics);
       }
     } catch (error) {
-      console.error("Failed to fetch topic suggestions", error);
+      console.error('Failed to fetch topic suggestions', error);
     }
   };
 
@@ -58,7 +48,7 @@ export default function HomePage() {
       const data: ProblemAnalysis = await res.json();
       setAnalysis(data);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "An unknown error occurred.");
+      setError(err instanceof Error ? err.message : 'An unknown error occurred.');
     } finally {
       setIsLoading(false);
     }
@@ -67,22 +57,19 @@ export default function HomePage() {
   const fetchRandomTopic = async () => {
     try {
       const res = await fetch(`${API_BASE_URL}/api/v1/analyze/random-topic`);
-      if (!res.ok) return "Global AI Regulation"; // Fallback
+      if (!res.ok) return 'Global AI Regulation'; // Fallback
       return await res.text();
     } catch (error) {
-      console.error("Failed to fetch random topic", error);
-      return "Global AI Regulation"; // Fallback
+      console.error('Failed to fetch random topic', error);
+      return 'Global AI Regulation'; // Fallback
     }
   };
 
   useEffect(() => {
     const loadInitialData = async () => {
-      // First, get a random topic for the initial load
       const initialTopic = await fetchRandomTopic();
       setTopicInput(initialTopic);
-      // Then, fetch the analysis for that topic
       fetchAnalysis(initialTopic);
-      // Also fetch the topic suggestions for the tags
       fetchTopicSuggestions();
     };
 
@@ -102,146 +89,53 @@ export default function HomePage() {
   };
 
   const handleClearClick = () => {
-    setTopicInput("");
+    setTopicInput('');
     setAnalysis(null);
     setError(null);
   };
 
-  
-
   return (
-    <main className="flex min-h-screen flex-col items-center p-4 md:p-8 lg:p-12 bg-gray-900 text-white">
-      <div className="w-full max-w-5xl font-sans">
-
-        {/* --- INTERACTION HEADER --- */}
-        <div className="p-4 mb-8 bg-gray-800 rounded-lg shadow-lg">
-          <h1 className="text-2xl font-bold text-center text-cyan-400 mb-4">Analyze a News Topic</h1>
-          <div className="flex flex-col sm:flex-row gap-2">
-            <input
-              type="text"
-              value={topicInput}
-              onChange={(e) => setTopicInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="Enter a topic (e.g., 'Global supply chain')"
-              className="flex-grow p-2 rounded bg-gray-700 text-white border border-gray-600 focus:outline-none focus:ring-2 focus:ring-cyan-500"
-            />
-            <button onClick={handleAnalyzeClick} disabled={isLoading} className="px-4 py-2 bg-cyan-600 rounded hover:bg-cyan-700 disabled:bg-gray-500 transition-colors">
-              {isLoading ? 'Analyzing...' : 'Analyze'}
-            </button>
-            <button
-              onClick={handleClearClick}
-              disabled={!topicInput}
-              className="px-4 py-2 bg-gray-600 rounded hover:bg-gray-700 disabled:bg-gray-500 transition-colors"
-            >
-              Clear
-            </button>
-          </div>
-
-          <div className="mt-4 pt-4 border-t border-gray-700">
-            <p className="text-center text-sm text-gray-400 mb-3">Or select a trending topic:</p>
-            <div className="flex flex-wrap justify-center items-center gap-2">
-              {suggestedTopics.length > 0 ? (
-                (showAllTopics ? suggestedTopics : suggestedTopics.slice(0, 4)).map(topic => (
-                  <button
-                    key={topic}
-                    onClick={() => { setTopicInput(topic); fetchAnalysis(topic); }}
-                    disabled={isLoading}
-                    className="px-3 py-1 bg-gray-700 text-sm rounded-full hover:bg-cyan-700 disabled:bg-gray-600 transition-colors"
-                  >
-                    {topic}
-                  </button>
-                ))
-              ) : (
-                <p className="text-xs text-gray-500">Loading topics...</p>
-              )}
-              {/* --- "Show More" Button Logic --- */}
-              {!showAllTopics && suggestedTopics.length > 4 && (
-                  <button onClick={() => setShowAllTopics(true)} className="px-3 py-1 text-sm text-cyan-400 hover:text-cyan-300">
-                      Show More...
-                  </button>
-              )}
-              {showAllTopics && suggestedTopics.length > 4 && (
-                  <button onClick={() => setShowAllTopics(false)} className="px-3 py-1 text-sm text-cyan-400 hover:text-cyan-300">
-                      Show Less
-                  </button>
-              )}
-            </div>
-          </div>
-
-          <div className="text-center mt-4">
-            <button onClick={handleRandomClick} disabled={isLoading || suggestedTopics.length === 0} className="text-sm text-gray-400 hover:text-cyan-400 disabled:text-gray-600 transition-colors">
-              or analyze a random topic
-            </button>
-          </div>
-        </div>
-
-        {/* --- DYNAMIC CONTENT DISPLAY --- */}
-        <div className="mt-8">
-          {isLoading && <LoadingSkeleton />}
-          {error && <ErrorMessage message={error} />}
-          {analysis && (
-            <div className="animate-fade-in">
-              <header className="mb-12 border-b border-gray-700 pb-4 text-center">
-                <h2 className="text-4xl font-bold text-cyan-400">{analysis.topic}</h2>
-                <p className="mt-3 text-lg text-gray-300 max-w-3xl mx-auto">{analysis.summary}</p>
-              </header>
-
-              <AnimatedSection>
-                <div className="p-6 bg-gray-800 rounded-lg shadow-lg">
-                  <h2 className="text-2xl font-semibold text-gray-200 mb-3">The Aggregated Problem</h2>
-                  <p className="text-lg text-gray-300 leading-relaxed">{analysis.aggregatedProblem}</p>
-                </div>
-              </AnimatedSection>
-
-              <AnimatedSection>
-                <h2 className="text-2xl font-semibold text-gray-200 mb-3 text-center">Proposed Solution</h2>
-                <p className="text-lg text-center text-cyan-300 leading-relaxed max-w-3xl mx-auto">{analysis.solutionProposal}</p>
-              </AnimatedSection>
-
-              <AnimatedSection>
-                <div className="grid md:grid-cols-2 gap-8 text-sm">
-                  <section className="p-4 border border-gray-700 rounded-lg">
-                    <h3 className="text-xl font-semibold text-gray-200 mb-3">Proposing Viewpoint</h3>
-                    <p className="text-gray-400 leading-relaxed">{analysis.proposingViewpoint}</p>
-                  </section>
-                  <section className="p-4 border border-gray-700 rounded-lg">
-                    <h3 className="text-xl font-semibold text-gray-200 mb-3">Opposing Viewpoint</h3>
-                    <p className="text-gray-400 leading-relaxed">{analysis.opposingViewpoint}</p>
-                  </section>
-                </div>
-              </AnimatedSection>
-
-              <AnimatedSection>
-                <h3 className="text-xl font-semibold text-gray-200 mb-3">Historical Perspective</h3>
-                <p className="text-gray-400 leading-relaxed">{analysis.historicalPerspective}</p>
-              </AnimatedSection>
-
-              <footer className="mt-12 pt-6 border-t border-gray-700 text-center">
-                <p className="text-md text-gray-500 italic">&quot;{analysis.motivationalProverb}&quot;</p>
-              </footer>
-            </div>
-          )}
-        </div>
+    <main className="min-h-screen bg-gray-100 text-gray-900">
+      <div className="container mx-auto px-4 py-6 sm:py-10 space-y-8">
+        <SearchBar
+          topic={topicInput}
+          onTopicChange={setTopicInput}
+          onAnalyze={handleAnalyzeClick}
+          onClear={handleClearClick}
+          onRandom={handleRandomClick}
+          isLoading={isLoading}
+          onKeyDown={handleKeyDown}
+        />
+        <TopicSuggestions
+          topics={suggestedTopics}
+          onSelect={(topic) => {
+            setTopicInput(topic);
+            fetchAnalysis(topic);
+          }}
+          isLoading={isLoading}
+        />
+        {isLoading && <LoadingSkeleton />}
+        {error && <ErrorMessage message={error} />}
+        {analysis && <AnalysisResults analysis={analysis} />}
       </div>
     </main>
   );
 }
 
 const LoadingSkeleton = () => (
-  <div className="w-full animate-pulse">
-    {/* Simplified version of your previous loading skeleton */}
-    <div className="h-10 bg-gray-700 rounded-md w-3/4 mx-auto mb-4"></div>
-    <div className="mt-4 h-5 bg-gray-700 rounded-md w-full"></div>
-    <div className="mt-8 p-6 bg-gray-800 rounded-lg">
-      <div className="h-8 bg-gray-700 rounded-md w-1/3 mb-4"></div>
-      <div className="h-6 bg-gray-700 rounded-md w-full"></div>
+  <div className="w-full animate-pulse space-y-4">
+    <div className="h-10 bg-gray-300 rounded-md w-3/4 mx-auto"></div>
+    <div className="h-5 bg-gray-300 rounded-md w-full"></div>
+    <div className="p-6 bg-white rounded shadow">
+      <div className="h-8 bg-gray-300 rounded-md w-1/3 mb-4"></div>
+      <div className="h-6 bg-gray-300 rounded-md w-full"></div>
     </div>
   </div>
 );
 
 const ErrorMessage = ({ message }: { message: string }) => (
-  <div className="p-4 bg-red-900/50 border border-red-700 rounded-lg text-center">
-    <p className="font-bold text-red-400">Analysis Failed</p>
-    <p className="text-red-300">{message}</p>
+  <div className="p-4 bg-red-100 border border-red-300 rounded-lg text-center">
+    <p className="font-bold text-red-600">Analysis Failed</p>
+    <p className="text-red-500">{message}</p>
   </div>
 );

--- a/app/types.ts
+++ b/app/types.ts
@@ -1,0 +1,10 @@
+export interface ProblemAnalysis {
+  topic: string;
+  summary: string;
+  aggregatedProblem: string;
+  solutionProposal: string;
+  proposingViewpoint: string;
+  opposingViewpoint: string;
+  historicalPerspective: string;
+  motivationalProverb: string;
+}


### PR DESCRIPTION
## Summary
- split home page into SearchBar, TopicSuggestions, and AnalysisResults components
- wrap content in responsive container for consistent spacing
- present analysis results in card-based layout with mobile-first styling

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Geist font from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_688dae916c20832daf1be6749b7e03e8