### PR TITLE
feat: refresh interface with modern styling

### DIFF
--- a/app/components/AnalysisResults.tsx
+++ b/app/components/AnalysisResults.tsx
@@ -7,48 +7,48 @@ interface AnalysisResultsProps {
 }
 
 export const AnalysisResults = ({ analysis }: AnalysisResultsProps) => (
-  <div className="space-y-8">
+  <div id="analysis-section" className="space-y-8">
     <header className="text-center space-y-3">
-      <h2 className="text-3xl sm:text-4xl font-bold text-cyan-600">{analysis.topic}</h2>
-      <p className="text-base sm:text-lg text-gray-700 max-w-3xl mx-auto">{analysis.summary}</p>
+      <h2 className="text-3xl sm:text-4xl font-bold text-cyan-400">{analysis.topic}</h2>
+      <p className="text-base sm:text-lg text-gray-300 max-w-3xl mx-auto">{analysis.summary}</p>
     </header>
 
     <AnimatedSection>
-      <div className="bg-white rounded shadow p-6">
+      <div className="bg-white/10 backdrop-blur rounded-lg border border-white/10 p-6">
         <h3 className="text-xl font-semibold mb-3">The Aggregated Problem</h3>
-        <p className="text-gray-700 leading-relaxed">{analysis.aggregatedProblem}</p>
+        <p className="text-gray-200 leading-relaxed">{analysis.aggregatedProblem}</p>
       </div>
     </AnimatedSection>
 
     <AnimatedSection>
-      <div className="bg-white rounded shadow p-6 text-center">
+      <div className="bg-white/10 backdrop-blur rounded-lg border border-white/10 p-6 text-center">
         <h3 className="text-xl font-semibold mb-3">Proposed Solution</h3>
-        <p className="text-gray-700 leading-relaxed">{analysis.solutionProposal}</p>
+        <p className="text-gray-200 leading-relaxed">{analysis.solutionProposal}</p>
       </div>
     </AnimatedSection>
 
     <AnimatedSection>
       <div className="grid sm:grid-cols-2 gap-6">
-        <div className="bg-white rounded shadow p-4">
+        <div className="bg-white/10 backdrop-blur rounded-lg border border-white/10 p-4">
           <h4 className="text-lg font-semibold mb-2">Proposing Viewpoint</h4>
-          <p className="text-gray-700 leading-relaxed">{analysis.proposingViewpoint}</p>
+          <p className="text-gray-200 leading-relaxed">{analysis.proposingViewpoint}</p>
         </div>
-        <div className="bg-white rounded shadow p-4">
+        <div className="bg-white/10 backdrop-blur rounded-lg border border-white/10 p-4">
           <h4 className="text-lg font-semibold mb-2">Opposing Viewpoint</h4>
-          <p className="text-gray-700 leading-relaxed">{analysis.opposingViewpoint}</p>
+          <p className="text-gray-200 leading-relaxed">{analysis.opposingViewpoint}</p>
         </div>
       </div>
     </AnimatedSection>
 
     <AnimatedSection>
-      <div className="bg-white rounded shadow p-4">
+      <div className="bg-white/10 backdrop-blur rounded-lg border border-white/10 p-4">
         <h4 className="text-lg font-semibold mb-2">Historical Perspective</h4>
-        <p className="text-gray-700 leading-relaxed">{analysis.historicalPerspective}</p>
+        <p className="text-gray-200 leading-relaxed">{analysis.historicalPerspective}</p>
       </div>
     </AnimatedSection>
 
     <footer className="text-center pt-4">
-      <p className="text-gray-500 italic">&quot;{analysis.motivationalProverb}&quot;</p>
+      <p className="text-gray-400 italic">&quot;{analysis.motivationalProverb}&quot;</p>
     </footer>
   </div>
 );

--- a/app/components/SearchBar.tsx
+++ b/app/components/SearchBar.tsx
@@ -20,28 +20,28 @@ export const SearchBar = ({
   isLoading,
   onKeyDown,
 }: SearchBarProps) => (
-  <div className="p-4 bg-gray-800 rounded-lg shadow space-y-4">
-    <h1 className="text-2xl font-bold text-center text-cyan-400">Analyze a News Topic</h1>
-    <div className="flex flex-col sm:flex-row gap-2">
+  <div className="p-6 bg-white/10 backdrop-blur rounded-xl shadow-lg space-y-6">
+    <h1 className="text-3xl font-bold text-center text-cyan-400">Analyze a News Topic</h1>
+    <div className="flex flex-col sm:flex-row gap-3">
       <input
         type="text"
         value={topic}
         onChange={(e) => onTopicChange(e.target.value)}
         onKeyDown={onKeyDown}
         placeholder="Enter a topic"
-        className="flex-1 px-4 py-2 rounded bg-gray-700 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+        className="flex-1 px-4 py-2 rounded-lg bg-white/5 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-cyan-500"
       />
       <button
         onClick={onAnalyze}
         disabled={isLoading}
-        className="px-4 py-2 bg-cyan-600 text-white rounded hover:bg-cyan-700 disabled:bg-cyan-400 transition-colors"
+        className="px-4 py-2 rounded-lg bg-gradient-to-r from-cyan-500 to-blue-600 text-white hover:from-cyan-400 hover:to-blue-500 disabled:from-cyan-700 disabled:to-blue-700 transition-colors"
       >
         {isLoading ? 'Analyzing...' : 'Analyze'}
       </button>
       <button
         onClick={onClear}
         disabled={!topic}
-        className="px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-700 disabled:bg-gray-500 transition-colors"
+        className="px-4 py-2 rounded-lg bg-white/5 text-white hover:bg-white/10 disabled:opacity-40 transition-colors"
       >
         Clear
       </button>
@@ -50,7 +50,7 @@ export const SearchBar = ({
       <button
         onClick={onRandom}
         disabled={isLoading}
-        className="text-sm text-gray-400 hover:text-cyan-400 disabled:text-gray-600 transition-colors"
+        className="text-sm text-gray-300 hover:text-cyan-400 disabled:text-gray-500 transition-colors"
       >
         or analyze a random topic
       </button>

--- a/app/components/TopicSuggestions.tsx
+++ b/app/components/TopicSuggestions.tsx
@@ -12,8 +12,8 @@ export const TopicSuggestions = ({ topics, onSelect, isLoading }: TopicSuggestio
   const visibleTopics = showAll ? topics : topics.slice(0, 4);
 
   return (
-    <div className="pt-4 border-t border-gray-700">
-      <p className="text-center text-sm text-gray-400 mb-3">Or select a trending topic:</p>
+    <div className="pt-6 border-t border-white/10">
+      <p className="text-center text-sm text-gray-300 mb-4">Or select a trending topic:</p>
       <div className="flex flex-wrap justify-center items-center gap-2">
         {topics.length > 0 ? (
           <>
@@ -22,7 +22,7 @@ export const TopicSuggestions = ({ topics, onSelect, isLoading }: TopicSuggestio
                 key={topic}
                 onClick={() => onSelect(topic)}
                 disabled={isLoading}
-                className="px-3 py-1 bg-gray-700 text-sm rounded-full hover:bg-cyan-700 disabled:bg-gray-600 transition-colors"
+                className="px-3 py-1 rounded-full bg-white/5 text-sm text-gray-200 hover:bg-cyan-600 disabled:opacity-40 transition-colors"
               >
                 {topic}
               </button>
@@ -45,7 +45,7 @@ export const TopicSuggestions = ({ topics, onSelect, isLoading }: TopicSuggestio
             )}
           </>
         ) : (
-          <p className="text-xs text-gray-500">Loading topics...</p>
+          <p className="text-xs text-gray-400">Loading topics...</p>
         )}
       </div>
     </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,26 +1,23 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --foreground: #f8fafc;
 }
 
 @theme inline {
-  --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
+@media (prefers-color-scheme: light) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --foreground: #171717;
   }
 }
 
 body {
-  background: var(--background);
+  background: linear-gradient(to bottom right, #0f172a, #1e293b);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,6 +47,9 @@ export default function HomePage() {
       }
       const data: ProblemAnalysis = await res.json();
       setAnalysis(data);
+      setTimeout(() => {
+        document.getElementById('analysis-section')?.scrollIntoView({ behavior: 'smooth' });
+      }, 100);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An unknown error occurred.');
     } finally {
@@ -95,8 +98,8 @@ export default function HomePage() {
   };
 
   return (
-    <main className="min-h-screen bg-gray-100 text-gray-900">
-      <div className="container mx-auto px-4 py-6 sm:py-10 space-y-8">
+    <main className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950 text-gray-100">
+      <div className="max-w-4xl mx-auto px-4 py-6 sm:py-10 space-y-8">
         <SearchBar
           topic={topicInput}
           onTopicChange={setTopicInput}
@@ -124,18 +127,18 @@ export default function HomePage() {
 
 const LoadingSkeleton = () => (
   <div className="w-full animate-pulse space-y-4">
-    <div className="h-10 bg-gray-300 rounded-md w-3/4 mx-auto"></div>
-    <div className="h-5 bg-gray-300 rounded-md w-full"></div>
-    <div className="p-6 bg-white rounded shadow">
-      <div className="h-8 bg-gray-300 rounded-md w-1/3 mb-4"></div>
-      <div className="h-6 bg-gray-300 rounded-md w-full"></div>
+    <div className="h-10 bg-white/10 rounded-md w-3/4 mx-auto"></div>
+    <div className="h-5 bg-white/10 rounded-md w-full"></div>
+    <div className="p-6 bg-white/10 rounded-lg border border-white/10">
+      <div className="h-8 bg-white/10 rounded-md w-1/3 mb-4"></div>
+      <div className="h-6 bg-white/10 rounded-md w-full"></div>
     </div>
   </div>
 );
 
 const ErrorMessage = ({ message }: { message: string }) => (
-  <div className="p-4 bg-red-100 border border-red-300 rounded-lg text-center">
-    <p className="font-bold text-red-600">Analysis Failed</p>
-    <p className="text-red-500">{message}</p>
+  <div className="p-4 bg-red-500/20 border border-red-500/30 rounded-lg text-center">
+    <p className="font-bold text-red-400">Analysis Failed</p>
+    <p className="text-red-300">{message}</p>
   </div>
 );


### PR DESCRIPTION
## Summary
- restyle search, suggestions and results with translucent cards and gradients
- add smooth scroll to analysis results and polished loading/error states

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688db812f670832d8f60a7d97a5b6350