### PR TITLE
feat: add theme-aware styling for settings button

### DIFF
--- a/app/components/SettingsPanel.tsx
+++ b/app/components/SettingsPanel.tsx
@@ -15,7 +15,7 @@ export const SettingsPanel: React.FC = () => {
       {/* Settings Button */}
       <button
         onClick={togglePanel}
-        className="fixed top-6 right-6 z-50 p-3 rounded-full bg-white/10 backdrop-blur-sm border border-white/20 text-white hover:bg-white/20 hover:scale-110 transition-all duration-200 cursor-pointer"
+        className="fixed top-6 right-6 z-50 p-3 rounded-full backdrop-blur-sm border transition-all duration-200 cursor-pointer hover:scale-110 bg-black/10 text-gray-900 border-black/20 hover:bg-black/20 dark:bg-white/10 dark:text-white dark:border-white/20 dark:hover:bg-white/20"
         aria-label="Open Settings"
       >
         <Settings className="h-5 w-5" />


### PR DESCRIPTION
## Summary
- update settings button to use light and dark theme classes for better contrast

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: next/font error fetching Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_688e20a5d3a0832d8b91ca7167195a96