### PR TITLE
Improve API error handling and user messaging

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,7 +50,12 @@ export default function HomePage() {
         document.getElementById('analysis-section')?.scrollIntoView({ behavior: 'smooth' });
       }, 100);
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'An unknown error occurred.';
+      let errorMessage = 'An unknown error occurred.';
+      if (err instanceof Error) {
+        errorMessage = err.message === 'Failed to fetch'
+          ? 'Backend unavailable—check server or API key'
+          : err.message;
+      }
       setError(errorMessage);
     } finally {
       setIsLoading(false);

--- a/app/services/apiService.ts
+++ b/app/services/apiService.ts
@@ -2,6 +2,10 @@ import { ProblemAnalysis } from '../types';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
+if (!API_BASE_URL) {
+  throw new Error('NEXT_PUBLIC_API_BASE_URL is not defined');
+}
+
 export class ApiService {
   async fetchTopicSuggestions(): Promise<string[]> {
     try {
@@ -13,6 +17,9 @@ export class ApiService {
       return Array.isArray(topics) ? topics : [];
     } catch (error) {
       console.error('Failed to fetch topic suggestions', error);
+      if (error instanceof TypeError) {
+        throw new Error('Backend unavailable—check server or API key');
+      }
       throw error;
     }
   }
@@ -26,6 +33,9 @@ export class ApiService {
       return await res.text();
     } catch (error) {
       console.error('Failed to fetch random topic', error);
+      if (error instanceof TypeError) {
+        throw new Error('Backend unavailable—check server or API key');
+      }
       throw error;
     }
   }
@@ -46,6 +56,9 @@ export class ApiService {
       return data;
     } catch (error) {
       console.error('Failed to fetch analysis', error);
+      if (error instanceof TypeError) {
+        throw new Error('Backend unavailable—check server or API key');
+      }
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- fail fast when `NEXT_PUBLIC_API_BASE_URL` is missing
- replace generic network errors with a clearer backend-unavailable message
- expose friendly backend errors in the home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f081f9cb0832db3bfec9b0797efc3